### PR TITLE
fix: alle 25 Security-Review-Findings beheben (#9–#33)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,8 +1,14 @@
 name: dependency-review
 
+# Issue #26: the dependency-review action is inherently diff-based and only
+# runs on pull requests / merge groups. Direct pushes to `main` (which would
+# bypass it) are prevented by the `main-protection` ruleset, which requires
+# every change to land via a reviewed PR. govulncheck in security.yml runs on
+# every push as a post-merge backstop.
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read
@@ -20,3 +26,7 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
+          # License compliance gate (issue #24): only permissive licenses are
+          # allowed for new/updated dependencies. A GPL/AGPL dependency would
+          # fail the check before it can be merged.
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,11 @@ on:
     tags:
       - 'v*'
 
+# Least privilege (issue #25): the workflow grants nothing by default; each
+# job below declares only the permissions it needs. In particular the build
+# jobs do NOT get contents:write — only the release job does.
 permissions:
-  contents: write
-  actions: read
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   # Security gate: every release runs the full security check suite AND is
@@ -61,6 +61,11 @@ jobs:
   build:
     name: Build ${{ matrix.artifact }}
     needs: security-gate
+    # Build needs OIDC for provenance attestation — but NOT contents:write.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         include:
@@ -110,6 +115,10 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    # Only this job writes to the repo (creates the Release); id-token for cosign.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Optionen:
   --org-id ID       Organisations-ID (auto-detected)
   --dry-run         Verbindung testen ohne Daten zu schreiben
   --timeout MIN     Gesamt-Timeout in Minuten (Standard: 120)
+  --audit           Hostname + Benutzer im Manifest erfassen (Audit-Trail)
   --version         Version anzeigen
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,52 +1,157 @@
 # Security Policy
 
-## Unterstützte Versionen
+## Supported Versions
 
-| Version | Sicherheitsupdates |
-|---------|-------------------|
-| Neuestes Release | ✓ |
-| Ältere Releases | — |
+Only the latest release receives security updates.
 
-Nur das jeweils neueste Release erhält Sicherheitsupdates.
+| Version | Security updates |
+|---------|-----------------|
+| Latest release | ✓ |
+| Older releases | — |
 
-## Sicherheitslücke melden
+## Reporting a Vulnerability
 
-**Bitte keine Sicherheitslücken als öffentliche GitHub Issues melden.**
+**Please do not report security vulnerabilities as public GitHub Issues.**
 
-Stattdessen bitte [GitHub Private Vulnerability Reporting](https://github.com/kAYd9iN/holaspirit-backup/security/advisories/new) nutzen. Das ermöglicht vertrauliche Koordination vor einer öffentlichen Offenlegung.
+Use [GitHub Private Vulnerability Reporting](https://github.com/kAYd9iN/holaspirit-backup/security/advisories/new)
+instead. This allows confidential coordination before public disclosure.
 
-### Inhalt der Meldung
+### Report contents
 
-- Beschreibung der Sicherheitslücke
-- Schritte zur Reproduktion
-- Mögliche Auswirkungen
-- Optional: vorgeschlagener Fix
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Optional: suggested fix
 
-### Reaktionszeit
+### Response times
 
-| Phase | Ziel |
-|-------|------|
-| Eingangsbestätigung | 5 Werktage |
-| Erstbewertung | 10 Werktage |
-| Fix für kritische Lücken | 30 Tage |
-| Fix für mittlere/niedrige Lücken | 90 Tage |
+| Phase | Target |
+|-------|--------|
+| Acknowledgement | 5 business days |
+| Initial assessment | 10 business days |
+| Fix for critical issues | 30 days |
+| Fix for medium/low issues | 90 days |
 
 ## Scope
 
-**In Scope:**
-- Sicherheitslücken im Tool-Code (`cmd/`, `internal/`)
-- Schwachstellen in CI/CD-Workflows (`.github/workflows/`)
-- Token-/Authentifizierungs-Schwachstellen
-- Supply-Chain-Risiken (Abhängigkeiten, Actions)
+**In scope:**
+- Vulnerabilities in tool code (`cmd/`, `internal/`)
+- Weaknesses in CI/CD workflows (`.github/workflows/`)
+- Token / authentication vulnerabilities
+- Supply-chain risks (dependencies, Actions)
 
-**Out of Scope:**
-- Holaspirit-API-Schwachstellen → direkt an Holaspirit melden
-- GitHub-Actions-Plattform-Schwachstellen → an GitHub melden
-- Probleme, die physischen Zugriff auf das Backup-System erfordern
+**Out of scope:**
+- Holaspirit API vulnerabilities → report directly to Holaspirit
+- GitHub Actions platform vulnerabilities → report to GitHub
+- Issues requiring physical access to the backup system
 
-## Sicherheitsarchitektur
+## Security Architecture
 
-Für eine vollständige Beschreibung aller Sicherheitsmaßnahmen siehe:
+- **GET-only HTTP client** — no write access to Holaspirit possible (`Get()` only)
+- **Explicit TLS policy** — minimum TLS 1.2, certificate verification cannot be
+  silently disabled (`InsecureSkipVerify` hard-set to `false`)
+- **Bearer token** — never logged or included in error messages
+- **HMAC-SHA-256 manifest signature** (`backup-manifest.sig`) — detects tampering
+- **File permissions** 0600 (files) / 0750 (directories)
+- **Path-traversal & symlink protection** in the storage writer — output paths
+  are sanitized, symlinks resolved, and containment is re-checked
+- **Log-injection protection** — API-supplied values are sanitized before logging
+- **Bounded memory** — per-response (100 MiB) and per-endpoint item caps
+- **vendor/ checked in** — reproducible builds, no network required
+- **License allowlist** — only permissive licenses (MIT, Apache-2.0, BSD, ISC)
+  are accepted for dependencies, enforced in CI
 
-- [Sicherheitskonzept](docs/security-concept.md) — Prinzipien, Token-Verwaltung, CI-Security
-- [Supply Chain & Vertrauenskette](docs/supply-chain.md) — SLSA L2, cosign, Scorecard, Verifikation
+For the full design see [docs/security-concept.md](docs/security-concept.md),
+[docs/supply-chain.md](docs/supply-chain.md), and the trust boundary description
+in [docs/trust-model.md](docs/trust-model.md).
+
+## Trust Model (summary)
+
+The backup output is **HMAC-verified, not sanitized**. The signature proves the
+manifest was produced by someone who possessed the API token at backup time — it
+does **not** guarantee that the backed-up JSON is free of adversarial content.
+Tools that consume backups must treat field values as untrusted data (never pass
+them unescaped to shells, SQL, or template engines). See
+[docs/trust-model.md](docs/trust-model.md) for the full data-flow and trust
+boundaries.
+
+## Backup Data Security (encryption at rest)
+
+Backup output is **not encrypted at rest**. The backup directory contains
+plaintext JSON of all organizational data, which may include PII (member names,
+emails, roles). The HMAC signature provides tamper detection only — **zero
+confidentiality**.
+
+**Operators are responsible for confidentiality.** Recommended mitigations:
+
+1. Store backups on an encrypted volume (LUKS, FileVault, BitLocker).
+2. Set restrictive filesystem permissions on the output directory (`chmod 700`).
+3. Restrict access via OS-level access controls.
+4. Encrypt with `age` or `gpg` before transferring backups off-site.
+
+This is an accepted design decision: the tool keeps a single responsibility
+(faithful backup + integrity), and delegates confidentiality to the storage
+layer, which is the appropriate trust boundary for at-rest protection.
+
+## Token Rotation
+
+The HMAC-SHA-256 manifest signature key is derived from the Holaspirit API
+token. **If the token is rotated, signatures of existing backups become
+unverifiable** (a false-positive "tampered" result).
+
+The token itself is never stored — only its derived HMAC key is used. To verify
+an old backup, supply the token that was in use when it was created. If you
+rotate tokens regularly and need long-term verifiability, re-sign archived
+manifests after rotation, or record which token generation signed each backup.
+
+## Backup Retention & Disposal
+
+No retention policy is enforced by the tool — timestamped backup directories
+accumulate indefinitely. Operators should:
+
+1. Define a retention period appropriate for their compliance requirements
+   (e.g. 90 days).
+2. Securely delete backups beyond the retention period (`shred`/`wipe` on
+   unencrypted media, or destroy the key for encrypted volumes).
+3. Audit who has access to the backup storage location.
+
+This satisfies GDPR storage-limitation expectations (Art. 5(1)(e)) at the
+operational layer.
+
+## Audit Trail
+
+By default the manifest records only the timestamp, tool version, and
+organization ID — host and user identifiers are **omitted** to minimize
+information exposure. Operators who require an audit trail (who ran a backup,
+from where, automated vs manual) can opt in with `--audit`, which records the
+hostname, username, and a CI-detected automation flag in the manifest.
+
+## Incident Response — compromised backup
+
+If a backup containing organizational data is exposed (e.g. storage breach,
+stolen device, misconfigured share), treat it as a **data breach**, not merely a
+tool issue:
+
+1. **Contain** — revoke access to the affected storage; identify which backup
+   directories and which endpoints (`members`, `tensions`, `policies`, etc.)
+   were exposed.
+2. **Rotate credentials** — rotate the Holaspirit API token, and any secrets
+   that may appear inside backed-up content (e.g. tokens written into tasks or
+   policies).
+3. **Assess scope** — the manifest lists every file and its hash; use it to
+   enumerate exposed data. PII (member names, emails) is the highest-sensitivity
+   class.
+4. **Notify** — if PII was exposed and you are subject to GDPR, the supervisory
+   authority must be notified within **72 hours** (Art. 33); affected data
+   subjects may need to be informed (Art. 34). Notify Holaspirit if their data
+   is involved.
+5. **Review** — confirm the at-rest mitigations above were in place; adjust
+   retention and access controls to reduce the exposed corpus next time.
+
+## Organization ID disclosure
+
+The organization ID is stored in the manifest and (after validation) logged.
+It is **not a secret** — it grants no access without a valid API token — but it
+is a stable identifier. It is intentionally not redacted, because it is required
+to identify which organization a backup belongs to. Treat manifests with the
+same care as the backup directory they describe.

--- a/cmd/backup/logsafe.go
+++ b/cmd/backup/logsafe.go
@@ -1,0 +1,13 @@
+package main
+
+import "regexp"
+
+// controlChars matches ASCII control characters and ANSI escape sequences.
+// API-supplied or operator-supplied strings are passed through sanitizeLog
+// before logging to prevent log injection (issue #18) — a value containing
+// "\n" or terminal escapes cannot forge additional log lines.
+var controlChars = regexp.MustCompile(`[\x00-\x1f\x7f]|\x1b\[[0-9;]*[a-zA-Z]`)
+
+func sanitizeLog(s string) string {
+	return controlChars.ReplaceAllString(s, "?")
+}

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/user"
 	"path/filepath"
 	"time"
 
@@ -13,6 +14,19 @@ import (
 	"github.com/kAYd9iN/holaspirit-backup/internal/backup"
 	"github.com/kAYd9iN/holaspirit-backup/internal/storage"
 )
+
+// auditInfo collects host and user identity for the optional --audit trail.
+// CI=true (set by GitHub Actions and most CI systems) marks the run automated.
+func auditInfo() *backup.AuditInfo {
+	a := &backup.AuditInfo{Automated: os.Getenv("CI") != ""}
+	if h, err := os.Hostname(); err == nil {
+		a.Hostname = h
+	}
+	if u, err := user.Current(); err == nil {
+		a.User = u.Username
+	}
+	return a
+}
 
 // version is set at build time via -ldflags "-X main.version=vX.Y.Z"
 var version = "dev"
@@ -38,6 +52,7 @@ func main() {
 	dryRun := flag.Bool("dry-run", false, "Test connection without writing files")
 	showVer := flag.Bool("version", false, "Show version and exit")
 	timeoutMin := flag.Int("timeout", 120, "Overall timeout in minutes (0 = no timeout)")
+	audit := flag.Bool("audit", false, "Record hostname and username in the manifest (audit trail)")
 	flag.Parse()
 
 	if *showVer {
@@ -68,13 +83,16 @@ func main() {
 			os.Exit(2)
 		}
 		*orgID = id
-		slog.Info("organization discovered", "id", *orgID)
 	}
 
+	// Validate BEFORE logging the org ID (issue #18): the value may come from
+	// an API response, so it is sanitized and format-checked before it ever
+	// reaches a log line.
 	if err := api.ValidateOrgID(*orgID); err != nil {
 		slog.Error("invalid organization ID", "error", err)
 		os.Exit(2)
 	}
+	slog.Info("organization confirmed", "id", sanitizeLog(*orgID))
 
 	if *dryRun {
 		slog.Info("dry run successful — connection OK")
@@ -93,19 +111,25 @@ func main() {
 	slog.Info("fetching endpoints", "count", len(endpoints))
 
 	manifest := backup.NewManifest(*orgID, version, ts)
+	if *audit {
+		manifest.SetAudit(auditInfo())
+	}
 	results := backup.RunFetchers(ctx, client, w, endpoints)
 
 	exitCode := 0
 	for _, r := range results {
+		// Endpoint names are compile-time constants, but they are sanitized
+		// before logging as defense-in-depth against log injection (issue #18).
+		safeName := sanitizeLog(r.Name)
 		if r.Err != nil {
-			slog.Warn("endpoint failed", "name", r.Name, "error", r.Err)
+			slog.Warn("endpoint failed", "name", safeName, "error", sanitizeLog(r.Err.Error()))
 			manifest.AddFailedFile(r.Name, r.Err)
 			exitCode = 1
 		} else {
-			slog.Info("endpoint ok", "name", r.Name, "records", r.Records)
+			slog.Info("endpoint ok", "name", safeName, "records", r.Records)
 			filePath := filepath.Join(w.Dir(), r.Name+".json")
 			if err := manifest.AddFile(filePath); err != nil {
-				slog.Warn("manifest hash failed", "name", r.Name, "error", err)
+				slog.Warn("manifest hash failed", "name", safeName, "error", sanitizeLog(err.Error()))
 			}
 		}
 	}

--- a/cmd/backup/verify.go
+++ b/cmd/backup/verify.go
@@ -18,6 +18,27 @@ func runVerify(dir string) int {
 		return 2
 	}
 
+	// Resolve --dir to an absolute, symlink-free path and require it to be a
+	// real directory before reading from it (issue #21). This prevents the
+	// verify path from being redirected through a symlink to a sensitive
+	// location and gives a clear error instead of a confusing read failure.
+	cleanDir, err := filepath.Abs(filepath.Clean(dir))
+	if err != nil {
+		slog.Error("invalid --dir", "dir", sanitizeLog(dir), "error", err)
+		return 2
+	}
+	resolved, err := filepath.EvalSymlinks(cleanDir)
+	if err != nil {
+		slog.Error("cannot resolve --dir", "dir", sanitizeLog(dir), "error", err)
+		return 2
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		slog.Error("--dir is not a directory", "dir", sanitizeLog(dir))
+		return 2
+	}
+	dir = resolved
+
 	manifestPath := filepath.Join(dir, "backup-manifest.json")
 	if err := backup.VerifyManifest(manifestPath, token); err != nil {
 		slog.Error("verification FAILED", "dir", dir, "error", err)

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,0 +1,60 @@
+# Trust Model
+
+This document defines the trust boundaries for holaspirit-backup so that future
+maintainers and anyone building restore/audit tooling on top of the backups have
+a clear baseline.
+
+## Data flow
+
+```
+Holaspirit API  ──TLS──▶  HTTP client (GET-only)  ──▶  JSON writer  ──▶  backup dir
+                                                                            │
+                                                              manifest signer (HMAC)
+                                                                            │
+                                                                  backup-manifest.{json,sig}
+```
+
+## Trust levels
+
+| Input / component | Trusted? | Notes |
+|-------------------|----------|-------|
+| API token | Trusted secret | Loaded from OS credential store or env; never logged, never written to disk. |
+| TLS connection to `app.holaspirit.com` | Trusted after verification | Min TLS 1.2, certificate verification enforced (cannot be disabled). |
+| **API response content** | **Untrusted** | The JSON bodies are stored verbatim. A compromised or misbehaving API could return adversarial field values. The tool does not interpret or execute them. |
+| `--output` path | Operator-controlled | Sanitized; symlinks resolved; writes are contained to the timestamped backup directory. |
+| `--dir` path (verify) | Operator-controlled | Resolved to an absolute, symlink-free directory and required to exist before reading. |
+| `.sig` file content | Untrusted | Decoded from hex and compared in constant time; malformed input yields a clear error, not a silent mismatch. |
+
+## What the HMAC signature guarantees — and what it does NOT
+
+The `backup-manifest.sig` HMAC proves:
+
+- ✅ The manifest was produced by a party that possessed the API token at backup
+  time.
+- ✅ The manifest (and therefore the recorded file hashes) has not been altered
+  since signing.
+
+It does **not** prove:
+
+- ❌ That the backup files contain benign content. The signature covers integrity
+  and origin, not safety. Field values originate from the API and are untrusted.
+- ❌ Authenticity relative to a separate signing identity. The key is derived from
+  the API token, so anyone with the token can produce a valid signature (see
+  [Token Rotation](../SECURITY.md#token-rotation)).
+
+## Guidance for restore / consumer tooling
+
+- **Do not** treat HMAC-verified data as safe to interpret. Verification proves
+  integrity, not that a field is free of injection payloads.
+- **Do not** pass backed-up field values unescaped into shells, SQL queries,
+  template engines, or HTML.
+- **Do** re-validate and escape every value at the point of use, exactly as you
+  would for any external/untrusted input.
+- **Do** verify the manifest signature before consuming a backup, and surface a
+  clear failure if it does not verify.
+
+## At-rest confidentiality
+
+Confidentiality of the backup directory is **out of scope** for the tool and is
+delegated to the storage layer (encrypted volumes, filesystem ACLs). See
+[Backup Data Security](../SECURITY.md#backup-data-security-encryption-at-rest).

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,8 +32,22 @@ type Client struct {
 }
 
 func NewClient(baseURL, token string) *Client {
+	// Explicit TLS policy (issues #12, #29): pin a minimum of TLS 1.2 and make
+	// it impossible to silently ship with certificate verification disabled.
+	// InsecureSkipVerify is hard-set to false so a future custom transport edit
+	// can't accidentally turn it off; the Bearer token must never traverse an
+	// unverified connection.
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: false,
+		},
+	}
 	return &Client{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: transport,
+		},
 		baseURL:    baseURL,
 		token:      token,
 		limiter:    rate.NewLimiter(rateLimit, rateBurst),

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strconv"
 )
 
 // HolaspiritResponse is the standard paginated API response envelope.
@@ -17,9 +19,22 @@ type HolaspiritResponse struct {
 	} `json:"meta"`
 }
 
-// maxPages is a hard cap on the number of pages fetched per endpoint,
-// preventing unbounded loops if the API returns inconsistent pagination metadata.
-const maxPages = 500
+const (
+	// maxPages is a hard cap on the number of pages fetched per endpoint,
+	// preventing unbounded loops if the API returns inconsistent pagination
+	// metadata.
+	maxPages = 500
+
+	// maxItemsPerEndpoint bounds the total number of accumulated items per
+	// endpoint (issue #19). FetchAllPages holds all items in memory before
+	// writing, so without this cap a misbehaving or hostile API could drive
+	// memory use unbounded (500 pages × 100 MiB). 1,000,000 items is far above
+	// any realistic Holaspirit org while keeping worst-case memory bounded.
+	maxItemsPerEndpoint = 1_000_000
+
+	// perPage is the page size requested from the API.
+	perPage = 100
+)
 
 // FetchAllPages retrieves all pages for a given endpoint and returns
 // the combined data items as raw JSON messages.
@@ -32,8 +47,13 @@ func FetchAllPages(ctx context.Context, client *Client, path string) ([]json.Raw
 			return nil, fmt.Errorf("pagination safety limit reached (%d pages) for %s", maxPages, path)
 		}
 
-		url := fmt.Sprintf("%s?page=%d&per_page=100", path, page)
-		body, err := client.Get(ctx, url)
+		// Build the query safely so a path with existing query characters or
+		// reserved bytes cannot corrupt the request URL (issue #30).
+		q := url.Values{}
+		q.Set("page", strconv.Itoa(page))
+		q.Set("per_page", strconv.Itoa(perPage))
+		reqPath := path + "?" + q.Encode()
+		body, err := client.Get(ctx, reqPath)
 		if err != nil {
 			return nil, fmt.Errorf("page %d of %s: %w", page, path, err)
 		}
@@ -50,6 +70,10 @@ func FetchAllPages(ctx context.Context, client *Client, path string) ([]json.Raw
 			break
 		}
 		allItems = append(allItems, items...)
+
+		if len(allItems) > maxItemsPerEndpoint {
+			return nil, fmt.Errorf("item safety limit reached (%d items) for %s — possible runaway pagination", maxItemsPerEndpoint, path)
+		}
 
 		if page >= resp.Meta.Pagination.TotalPages || resp.Meta.Pagination.TotalPages == 0 {
 			break

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -88,3 +88,27 @@ func TestFetchAllPages_EmptyResponse(t *testing.T) {
 		t.Errorf("expected 0 items, got %d", len(items))
 	}
 }
+
+func TestFetchAllPages_EncodesQueryParams(t *testing.T) {
+	var gotQueries []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"id": "1"}},
+			"meta": map[string]any{"pagination": map[string]any{"current_page": 1, "total_pages": 1}},
+		})
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(srv.URL, "tok")
+	if _, err := api.FetchAllPages(context.Background(), c, "/circles"); err != nil {
+		t.Fatal(err)
+	}
+	if len(gotQueries) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(gotQueries))
+	}
+	// url.Values.Encode sorts keys alphabetically: page before per_page.
+	if gotQueries[0] != "page=1&per_page=100" {
+		t.Errorf("unexpected encoded query: %q", gotQueries[0])
+	}
+}

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -9,9 +9,34 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// maxManifestFileBytes caps how much of a backup file is read for hashing,
+// so an unexpectedly large file cannot exhaust memory (issue #14). It matches
+// the client's per-response body limit.
+const maxManifestFileBytes = 100 * 1024 * 1024 // 100 MiB
+
+// errorSanitizer strips ASCII control characters and ANSI escapes from error
+// strings before they are stored in the manifest, preventing log/JSON injection
+// and reducing the chance of leaking unexpected response content (issue #15).
+var errorSanitizer = regexp.MustCompile(`[\x00-\x1f\x7f]|\x1b\[[0-9;]*[a-zA-Z]`)
+
+// sanitizeError makes an error string safe to persist: control characters are
+// replaced and the message is truncated to a sane length.
+func sanitizeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := errorSanitizer.ReplaceAllString(err.Error(), "?")
+	const maxLen = 512
+	if len(s) > maxLen {
+		s = s[:maxLen] + "…(truncated)"
+	}
+	return s
+}
 
 // FileEntry records integrity data for one backup file.
 type FileEntry struct {
@@ -29,11 +54,21 @@ type Summary struct {
 	Failed     int `json:"failed"`
 }
 
+// AuditInfo records who ran a backup and from where. It is populated only when
+// the operator opts in via --audit (issue #33); it is omitted by default to
+// avoid embedding host/user identifiers in every backup (issue #28).
+type AuditInfo struct {
+	Hostname string `json:"hostname,omitempty"`
+	User     string `json:"user,omitempty"`
+	Automated bool  `json:"automated,omitempty"`
+}
+
 // Manifest records the full backup run metadata and per-file integrity hashes.
 type Manifest struct {
 	Timestamp      time.Time   `json:"timestamp"`
 	ToolVersion    string      `json:"tool_version"`
 	OrganizationID string      `json:"organization_id"`
+	Audit          *AuditInfo  `json:"audit,omitempty"`
 	Files          []FileEntry `json:"files"`
 	Summary        Summary     `json:"summary"`
 }
@@ -46,6 +81,11 @@ func NewManifest(orgID, version string, ts time.Time) *Manifest {
 	}
 }
 
+// SetAudit attaches optional audit metadata (issue #33). No-op for nil.
+func (m *Manifest) SetAudit(a *AuditInfo) {
+	m.Audit = a
+}
+
 // AddFile hashes the file at path and records it as a successful entry.
 func (m *Manifest) AddFile(path string) error {
 	f, err := os.Open(path) // #nosec G304 — path is always an internally constructed backup path
@@ -55,7 +95,7 @@ func (m *Manifest) AddFile(path string) error {
 	defer f.Close()
 
 	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
+	if _, err := io.Copy(h, io.LimitReader(f, maxManifestFileBytes)); err != nil {
 		return fmt.Errorf("hash %s: %w", path, err)
 	}
 
@@ -72,7 +112,7 @@ func (m *Manifest) AddFailedFile(name string, err error) {
 	m.Files = append(m.Files, FileEntry{
 		Name:   name + ".json",
 		Status: "failed",
-		Error:  err.Error(),
+		Error:  sanitizeError(err),
 	})
 }
 
@@ -116,8 +156,20 @@ func VerifyManifest(manifestPath, token string) error {
 		return fmt.Errorf("read sig: %w", err)
 	}
 
-	expected := computeHMAC(data, token)
-	if !hmac.Equal([]byte(expected), sigBytes) {
+	// Compare the raw HMAC bytes, not the hex strings (issue #13). Decoding
+	// first means a stray trailing newline or whitespace in the .sig file
+	// yields a clear "malformed signature" error instead of a misleading
+	// "tampered" verdict, and the constant-time compare operates on the
+	// actual MAC bytes.
+	expectedBytes, err := hex.DecodeString(computeHMAC(data, token))
+	if err != nil {
+		return fmt.Errorf("compute expected signature: %w", err)
+	}
+	storedBytes, err := hex.DecodeString(strings.TrimSpace(string(sigBytes)))
+	if err != nil {
+		return fmt.Errorf("malformed signature file (%s): not valid hex", sigPath)
+	}
+	if !hmac.Equal(expectedBytes, storedBytes) {
 		return fmt.Errorf("manifest signature mismatch — backup may have been tampered with")
 	}
 	return nil

--- a/internal/backup/manifest_test.go
+++ b/internal/backup/manifest_test.go
@@ -120,3 +120,68 @@ func TestManifestTokenNotInOutput(t *testing.T) {
 		t.Error("token substring found in manifest.sig")
 	}
 }
+
+func TestVerifyManifest_RejectsMalformedSignature(t *testing.T) {
+	dir := t.TempDir()
+	mPath := filepath.Join(dir, "backup-manifest.json")
+	if err := os.WriteFile(mPath, []byte(`{"files":[]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// .sig with non-hex content must yield a clear "malformed" error, not a
+	// silent "tampered" verdict (issue #13).
+	if err := os.WriteFile(filepath.Join(dir, "backup-manifest.sig"), []byte("not-hex-!!"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err := backup.VerifyManifest(mPath, "tok")
+	if err == nil || !strings.Contains(err.Error(), "malformed signature") {
+		t.Errorf("expected malformed-signature error, got: %v", err)
+	}
+}
+
+func TestVerifyManifest_ToleratesTrailingNewlineInSig(t *testing.T) {
+	dir := t.TempDir()
+	m := backup.NewManifest("org", "test", time.Now())
+	mPath := filepath.Join(dir, "backup-manifest.json")
+	if err := m.Write(mPath, "tok"); err != nil {
+		t.Fatal(err)
+	}
+	// Append a trailing newline to the .sig — a common artifact of text tools.
+	sigPath := filepath.Join(dir, "backup-manifest.sig")
+	sig, _ := os.ReadFile(sigPath)
+	if err := os.WriteFile(sigPath, append(sig, '\n'), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := backup.VerifyManifest(mPath, "tok"); err != nil {
+		t.Errorf("trailing newline in sig should still verify, got: %v", err)
+	}
+}
+
+func TestAddFailedFile_SanitizesControlChars(t *testing.T) {
+	dir := t.TempDir()
+	m := backup.NewManifest("org", "test", time.Now())
+	m.AddFailedFile("evil", fmtErr("line1\nFAKE: injected\x1b[31m"))
+	mPath := filepath.Join(dir, "backup-manifest.json")
+	if err := m.Write(mPath, "tok"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(mPath)
+	// The stored error must not contain raw newlines or escape bytes (issue #15/#18).
+	var parsed struct {
+		Files []struct {
+			Error string `json:"error"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Files) != 1 {
+		t.Fatalf("expected 1 file entry, got %d", len(parsed.Files))
+	}
+	if strings.ContainsAny(parsed.Files[0].Error, "\n\x1b\x00") {
+		t.Errorf("error string not sanitized: %q", parsed.Files[0].Error)
+	}
+}
+
+type fmtErr string
+
+func (e fmtErr) Error() string { return string(e) }

--- a/internal/backup/runner.go
+++ b/internal/backup/runner.go
@@ -31,6 +31,11 @@ func RunFetchers(ctx context.Context, client *api.Client, w *storage.Writer, end
 	results := make([]Result, len(endpoints))
 	var wg sync.WaitGroup
 
+	// Concurrency safety (issue #16): each job carries a unique index and every
+	// worker writes only to results[job.idx]; no two goroutines ever touch the
+	// same element, so the writes do not race under the Go memory model. The
+	// slice is read only after wg.Wait() establishes happens-before ordering.
+	// The -race detector in CI guards this invariant against future refactors.
 	for i := 0; i < workerCount; i++ {
 		wg.Add(1)
 		go func() {

--- a/internal/storage/writer.go
+++ b/internal/storage/writer.go
@@ -27,11 +27,38 @@ type Writer struct {
 }
 
 func NewWriter(baseDir string, ts time.Time) (*Writer, error) {
+	// Symlink hardening (issue #17): resolve the operator-supplied baseDir
+	// through any symlinks before writing into it. If baseDir is a symlink
+	// to a sensitive location (e.g. /etc), the backup must not follow it.
+	// A not-yet-existing baseDir is fine — only an existing symlink target is
+	// resolved and re-checked.
+	if resolved, err := filepath.EvalSymlinks(baseDir); err == nil {
+		baseDir = resolved
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("resolve output dir %q: %w", baseDir, err)
+	}
+
 	dir := filepath.Join(baseDir, ts.UTC().Format("2006-01-02T15-04-05"))
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, fmt.Errorf("create backup dir: %w", err)
 	}
-	return &Writer{dir: dir}, nil
+
+	// Re-resolve the created directory and confirm it still sits under the
+	// intended base — guards against a symlink swapped in between the checks.
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve backup dir: %w", err)
+	}
+	resolvedBase, err := filepath.EvalSymlinks(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve base dir: %w", err)
+	}
+	rel, err := filepath.Rel(resolvedBase, resolvedDir)
+	if err != nil || isOutsideDir(rel) {
+		return nil, fmt.Errorf("backup dir %q escapes base %q after symlink resolution", resolvedDir, resolvedBase)
+	}
+
+	return &Writer{dir: resolvedDir}, nil
 }
 
 func (w *Writer) Dir() string { return w.dir }


### PR DESCRIPTION
Behebt sämtliche offenen Findings des Security-Reviews, sodass das Release-Security-Gate freigibt. Vorgehen analog zu confluence-backup: echte Code-Fixes für die technischen Findings, dokumentierte Design-Entscheidungen (SECURITY.md / docs/trust-model.md) für die Architektur-Findings.

### Code-Fixes
| # | Finding | Fix |
|---|---------|-----|
| #12/#29 | TLS nicht explizit | `MinVersion: TLS1.2`, `InsecureSkipVerify` hart auf `false` |
| #13 | HMAC-Hex-Vergleich fragil | Vergleich auf decodierten Rohbytes; toleriert trailing-Whitespace, klare Fehlermeldung bei Nicht-Hex |
| #14 | `AddFile` ohne Größenlimit | `io.LimitReader` (100 MiB) |
| #15 | Roh-Fehlerstrings im Manifest | Sanitisierung (Control-Chars raus, Länge gekappt) |
| #16 | Race-Pattern | Invariante (disjunkte Indizes) dokumentiert; `-race` deckt ab |
| #17 | Symlink auf `--output` | `EvalSymlinks` + Containment-Recheck im Writer |
| #18 | Log-Injection | `sanitizeLog` auf alle API-/Operator-Werte; orgID erst nach Validierung geloggt |
| #19 | DoS via Pagination | Gesamt-Item-Cap (1 Mio.) pro Endpoint |
| #21 | `verify --dir` Traversal | Auflösung auf absoluten, symlink-freien, existierenden Ordner |
| #30 | URL-Konstruktion | `url.Values` statt `fmt.Sprintf` |
| #33 | Kein Audit-Trail | Opt-in `--audit` (Hostname/User/Automated im Manifest) |

### Workflow-Fixes
- **#25**: Least-Privilege — Top-Level `contents:read`; Build nur `id-token`+`attestations`; `contents:write` nur im Release-Job
- **#24**: Lizenz-Allowlist (MIT/Apache-2.0/BSD/ISC) in dependency-review erzwungen
- **#26**: `main-protection`-Ruleset blockiert direkte Pushes (dokumentiert) + `merge_group`-Trigger

### Durch frühere Arbeit / by design gelöst (dokumentiert)
- **#20, #22**: Der credential-freie Spec-Drift-Check nutzt keinen Token/keine Org-ID mehr → Shell-Injection- und Live-Credential-Sorge entfallen
- **#9** (Verschlüsselung-at-Rest), **#10** (Token-Rotation/HMAC), **#11** (Retention), **#23** (Incident-Response), **#27** (Trust-Model), **#28** (OrgID): als Operator-Verantwortung / akzeptierte Design-Entscheidung in SECURITY.md + neuer docs/trust-model.md dokumentiert
- **#31**: SECURITY.md auf Englisch neu geschrieben

### Verifikation
4 neue Tests (Hex-Decode-Ablehnung, Trailing-Newline-Toleranz, Error-Sanitisierung, Pagination-URL-Encoding). `go build`/`vet`/`test` + gosec (0 Issues) lokal grün.

**Nach Merge:** Alle 25 Issues werden geschlossen → Security-Gate gibt frei → die nächste api-drift-Schlaufe (oder ein manueller Tag) produziert den ersten regulären Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)