### PR TITLE
feat: echter CBOM mit NIST-Krypto-Policy-Gate (conftest/OPA)

### DIFF
--- a/.github/workflows/cbom.yml
+++ b/.github/workflows/cbom.yml
@@ -21,40 +21,52 @@ jobs:
           go-version: '1.26'
           cache: true
 
-      - name: Generate SBoM
+      - name: Generate dependency SBoM
         run: |
-          # cdxgen --type cryptography produces empty results for Go projects because
-          # stdlib crypto packages (crypto/hmac, crypto/sha256 etc.) are not go.mod
-          # dependencies and are not detected via source analysis.
-          # We generate a standard Go SBoM instead: all module dependencies with
-          # PURLs, hashes, and licenses. Crypto algorithms are documented in
-          # docs/security-concept.md.
+          # cdxgen --type go produces a dependency SBoM (modules, PURLs, hashes,
+          # licenses). It is NOT a CBOM: Go stdlib crypto is not a go.mod
+          # dependency, so it never appears here. The real Cryptography BoM is
+          # the hand-authored, policy-checked docs/cbom.cdx.json (below).
           npx --yes @cyclonedx/cdxgen@12.1.1 \
             --type go \
-            --output cbom.cdx.json \
+            --output sbom.cdx.json \
             .
 
-      - name: Optional sign SBoM
+      - name: Validate CBOM is consistent with the source
+        run: bash scripts/check-cbom.sh
+
+      - name: Check CBOM against NIST crypto policy (informational)
+        run: |
+          # Same policy the release gate enforces. Here it is informational so
+          # PRs surface crypto findings early; the hard gate lives in release.yml.
+          go run github.com/open-policy-agent/conftest@v0.68.2 \
+            test docs/cbom.cdx.json --policy policy
+
+      - name: Optional sign BoMs
         env:
           CBOM_SIGNING_KEY_PEM: ${{ secrets.CBOM_SIGNING_KEY_PEM }}
         run: |
           set -euo pipefail
           if [ -z "${CBOM_SIGNING_KEY_PEM:-}" ]; then
-            echo "No CBOM_SIGNING_KEY_PEM configured; unsigned SBoM artifact only."
+            echo "No CBOM_SIGNING_KEY_PEM configured; unsigned artifacts only."
             exit 0
           fi
           printf '%s\n' "${CBOM_SIGNING_KEY_PEM}" > /tmp/cbom-key.pem
-          if ! openssl dgst -sha256 -sign /tmp/cbom-key.pem -out cbom.cdx.json.sig cbom.cdx.json; then
-            echo "Signing failed. Continuing with unsigned artifact."
-            rm -f cbom.cdx.json.sig
-          fi
+          for f in sbom.cdx.json docs/cbom.cdx.json; do
+            if ! openssl dgst -sha256 -sign /tmp/cbom-key.pem -out "$f.sig" "$f"; then
+              echo "Signing $f failed. Continuing with unsigned artifact."
+              rm -f "$f.sig"
+            fi
+          done
           rm -f /tmp/cbom-key.pem
 
-      - name: Upload SBoM artifacts
+      - name: Upload SBoM + CBOM artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: cbom-cyclonedx
+          name: bom-cyclonedx
           path: |
-            cbom.cdx.json
-            cbom.cdx.json.sig
+            sbom.cdx.json
+            sbom.cdx.json.sig
+            docs/cbom.cdx.json
+            docs/cbom.cdx.json.sig
           retention-days: 365

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,17 @@ jobs:
       - name: Unit tests (race detector)
         run: go test -race -cover ./...
 
+      - name: CBOM is consistent with the source
+        run: bash scripts/check-cbom.sh
+
+      - name: Block release on non-NIST cryptography (CBOM policy)
+        run: |
+          # Hard gate: deny rules in policy/nist-crypto.rego fail the build if any
+          # cryptographic asset in docs/cbom.cdx.json is not NIST-approved (weak
+          # algorithm, or TLS < 1.2). Quantum-readiness findings are warn-only.
+          go run github.com/open-policy-agent/conftest@v0.68.2 \
+            test docs/cbom.cdx.json --policy policy
+
       - name: Block release on open security findings
         env:
           GH_TOKEN: ${{ github.token }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -148,6 +148,22 @@ tool issue:
 5. **Review** — confirm the at-rest mitigations above were in place; adjust
    retention and access controls to reduce the exposed corpus next time.
 
+## Cryptography Bill of Materials (CBOM)
+
+The tool's cryptographic surface is enumerated in a CycloneDX 1.6 CBOM at
+[`docs/cbom.cdx.json`](docs/cbom.cdx.json): SHA-256 (hashing), HMAC-SHA-256
+(manifest signature), TLS ≥ 1.2 (transport), and ECDSA P-256 (cosign release
+signing). Automated scanners do not detect Go stdlib crypto, so the CBOM is
+hand-authored and kept honest by `scripts/check-cbom.sh`, which fails CI if a
+crypto import is not declared in it.
+
+The CBOM is checked against a **NIST SP 800-131A / FIPS-approved** policy
+([`policy/nist-crypto.rego`](policy/nist-crypto.rego), Open Policy Agent /
+conftest). A non-approved algorithm (e.g. MD5, SHA-1, RC4, or TLS < 1.2) fails
+the **release security gate** and blocks the release. Quantum-readiness is
+reported as a non-gating warning: ECDSA P-256 is NIST-approved but not
+quantum-safe, tracked for future post-quantum migration.
+
 ## Organization ID disclosure
 
 The organization ID is stored in the manifest and (after validation) logged.

--- a/docs/cbom.cdx.json
+++ b/docs/cbom.cdx.json
@@ -1,0 +1,82 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "name": "holaspirit-backup",
+      "bom-ref": "pkg:golang/github.com/kAYd9iN/holaspirit-backup"
+    },
+    "properties": [
+      {
+        "name": "cbom:source",
+        "value": "Hand-authored Cryptography Bill of Materials. The crypto surface of this tool is small and stable; automated scanners (cdxgen, cbomkit-theia) do not detect Go stdlib crypto, so this CBOM is maintained by hand and kept honest by scripts/check-cbom.sh, which fails CI if a crypto import in internal/ or cmd/ is not represented here."
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "cryptographic-asset",
+      "name": "SHA-256",
+      "bom-ref": "crypto/sha-256",
+      "description": "File integrity hashing (manifest) and HMAC key derivation input. Go crypto/sha256.",
+      "cryptoProperties": {
+        "assetType": "algorithm",
+        "algorithmProperties": {
+          "primitive": "hash",
+          "parameterSetIdentifier": "256",
+          "cryptoFunctions": ["digest"],
+          "nistQuantumSecurityLevel": 2
+        },
+        "oid": "2.16.840.1.101.3.4.2.1"
+      }
+    },
+    {
+      "type": "cryptographic-asset",
+      "name": "HMAC-SHA-256",
+      "bom-ref": "crypto/hmac-sha-256",
+      "description": "Manifest signature (backup-manifest.sig). Go crypto/hmac over SHA-256.",
+      "cryptoProperties": {
+        "assetType": "algorithm",
+        "algorithmProperties": {
+          "primitive": "mac",
+          "parameterSetIdentifier": "256",
+          "cryptoFunctions": ["tag", "verify"],
+          "nistQuantumSecurityLevel": 2
+        },
+        "oid": "1.2.840.113549.2.9"
+      }
+    },
+    {
+      "type": "cryptographic-asset",
+      "name": "TLS v1.2",
+      "bom-ref": "crypto/tls-1.2",
+      "description": "Minimum TLS version enforced on the API HTTP client transport (crypto/tls MinVersion VersionTLS12).",
+      "cryptoProperties": {
+        "assetType": "protocol",
+        "protocolProperties": {
+          "type": "tls",
+          "version": "1.2"
+        }
+      }
+    },
+    {
+      "type": "cryptographic-asset",
+      "name": "ECDSA",
+      "bom-ref": "crypto/ecdsa-p256",
+      "description": "Release artifact signing via cosign / Sigstore keyless (ECDSA over NIST P-256). Used in CI release.yml, not in the tool binary at runtime.",
+      "cryptoProperties": {
+        "assetType": "algorithm",
+        "algorithmProperties": {
+          "primitive": "signature",
+          "parameterSetIdentifier": "P-256",
+          "curve": "P-256",
+          "cryptoFunctions": ["sign", "verify"],
+          "nistQuantumSecurityLevel": 1
+        },
+        "oid": "1.2.840.10045.4.3.2"
+      }
+    }
+  ]
+}

--- a/policy/nist-crypto.rego
+++ b/policy/nist-crypto.rego
@@ -1,0 +1,74 @@
+package main
+
+# NIST SP 800-131A / FIPS-approved cryptographic policy for the project CBOM
+# (docs/cbom.cdx.json), evaluated with conftest (Open Policy Agent).
+#
+#   deny  -> FAILS the check and gates the release.
+#   warn  -> informational only; does NOT fail (quantum-readiness signal).
+#
+# Run locally:  conftest test docs/cbom.cdx.json --policy policy
+
+import rego.v1
+
+# Algorithms approved for use under NIST SP 800-131A / FIPS 140-3.
+approved_algorithms := {
+	"SHA-256", "SHA-384", "SHA-512",
+	"SHA3-256", "SHA3-384", "SHA3-512",
+	"HMAC-SHA-256", "HMAC-SHA-384", "HMAC-SHA-512",
+	"AES-128", "AES-192", "AES-256",
+	"ECDSA", "RSA", "EdDSA",
+	"ECDH",
+	"ML-DSA", "ML-KEM", "SLH-DSA",
+}
+
+# Substrings that mark a definitively weak / disallowed primitive.
+weak_markers := {"md5", "md4", "sha-1", "sha1", "rc4", "des", "3des", "tripledes", "blowfish", "rsa-1024"}
+
+# Classical asymmetric algorithms: NIST-approved today, but not quantum-safe.
+classical_asymmetric := {"ECDSA", "RSA", "ECDH", "DH", "DSA", "EdDSA"}
+
+is_algorithm(c) if {
+	c.type == "cryptographic-asset"
+	c.cryptoProperties.assetType == "algorithm"
+}
+
+weak_named(n) if {
+	some marker in weak_markers
+	contains(lower(n), marker)
+}
+
+# DENY: explicitly weak algorithm anywhere in the CBOM.
+deny contains msg if {
+	some c in input.components
+	c.type == "cryptographic-asset"
+	weak_named(c.name)
+	msg := sprintf("NIST policy violation: weak cryptographic algorithm %q is not permitted.", [c.name])
+}
+
+# DENY: an algorithm asset whose name is not on the approved allowlist (fail closed).
+deny contains msg if {
+	some c in input.components
+	is_algorithm(c)
+	not approved_algorithms[c.name]
+	not weak_named(c.name)
+	msg := sprintf("NIST policy violation: algorithm %q is not on the NIST-approved allowlist.", [c.name])
+}
+
+# DENY: TLS protocol below version 1.2.
+deny contains msg if {
+	some c in input.components
+	c.type == "cryptographic-asset"
+	c.cryptoProperties.assetType == "protocol"
+	c.cryptoProperties.protocolProperties.type == "tls"
+	ver := c.cryptoProperties.protocolProperties.version
+	to_number(ver) < 1.2
+	msg := sprintf("NIST policy violation: TLS version %s is below the required minimum of 1.2.", [ver])
+}
+
+# WARN: classical asymmetric algorithm — NIST-approved but not quantum-safe.
+warn contains msg if {
+	some c in input.components
+	is_algorithm(c)
+	classical_asymmetric[c.name]
+	msg := sprintf("Informational (non-gating): %q is NIST-approved but not quantum-safe; track for post-quantum migration.", [c.name])
+}

--- a/scripts/check-cbom.sh
+++ b/scripts/check-cbom.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# check-cbom.sh
+#
+# Keeps docs/cbom.cdx.json honest. Automated scanners do not detect Go stdlib
+# crypto, so the CBOM is hand-authored — this script fails CI if a crypto
+# package is imported in internal/ or cmd/ but is NOT represented in the CBOM,
+# or if a crypto package appears that this script does not know how to map
+# (forcing a conscious CBOM update before new crypto can be merged).
+#
+# Direction enforced: source import  ==>  CBOM asset (every crypto used must be
+# declared). The reverse is intentionally not enforced: the CBOM may list
+# release-side assets such as ECDSA (cosign) that are not Go imports.
+#
+# Exit codes: 0 = consistent, 1 = drift (missing or unknown crypto)
+
+set -euo pipefail
+
+CBOM="docs/cbom.cdx.json"
+SRC_DIRS=("internal" "cmd")
+
+[[ -f "$CBOM" ]] || { echo "ERROR: $CBOM not found" >&2; exit 1; }
+
+# Map a crypto/<pkg> import to a string that MUST appear in the CBOM.
+# Packages that are not cryptographic assets in their own right map to "-".
+cbom_asset_for() {
+	case "$1" in
+		sha256) echo "SHA-256" ;;
+		sha512) echo "SHA-512" ;;
+		sha1)   echo "SHA-1" ;;   # present only so the policy can reject it
+		md5)    echo "MD5" ;;
+		hmac)   echo "HMAC-SHA-256" ;;
+		tls)    echo "TLS v1.2" ;;
+		aes)    echo "AES-256" ;;
+		ecdsa)  echo "ECDSA" ;;
+		ed25519) echo "EdDSA" ;;
+		rsa)    echo "RSA" ;;
+		rand|subtle) echo "-" ;;  # RNG / constant-time helpers — not assets
+		*)      echo "?" ;;        # unknown — force a CBOM + script update
+	esac
+}
+
+# Collect crypto/<pkg> imports from non-test source files.
+mapfile -t pkgs < <(
+	grep -rhoE '"crypto/[a-z0-9]+"' "${SRC_DIRS[@]}" --include='*.go' \
+		--exclude='*_test.go' 2>/dev/null \
+		| sed -E 's@"crypto/([a-z0-9]+)"@\1@' | sort -u
+)
+
+status=0
+for pkg in "${pkgs[@]}"; do
+	asset="$(cbom_asset_for "$pkg")"
+	case "$asset" in
+		"-")
+			: ;; # non-asset crypto package, nothing to assert
+		"?")
+			echo "DRIFT: crypto/$pkg is imported but unknown to check-cbom.sh." >&2
+			echo "       Add it to docs/cbom.cdx.json and to cbom_asset_for() in this script." >&2
+			status=1 ;;
+		*)
+			if ! grep -q "\"$asset\"" "$CBOM"; then
+				echo "DRIFT: crypto/$pkg is imported but asset '$asset' is missing from $CBOM." >&2
+				status=1
+			fi ;;
+	esac
+done
+
+if [[ "$status" -eq 0 ]]; then
+	echo "CBOM consistent: every crypto import in ${SRC_DIRS[*]} is declared in $CBOM." >&2
+fi
+exit "$status"


### PR DESCRIPTION
Spiegelt confluence-backup. Der `cbom.yml`-Workflow erzeugte einen **Dependency-SBoM** mit **null `cryptographic-asset`-Komponenten** — ein CBOM-Compliance-Checker läuft darauf **vacuous pass**. Dieser PR fügt einen echten CBOM hinzu und erzwingt ihn.

| Datei | Zweck |
|-------|-------|
| `docs/cbom.cdx.json` | Hand-gepflegter CycloneDX-1.6-CBOM: SHA-256, HMAC-SHA-256, TLS ≥1.2, ECDSA P-256 (cosign) |
| `policy/nist-crypto.rego` | OPA/conftest: `deny` = nicht-NIST-approved **blockiert Release**; `warn` = nicht quantensicher (ECDSA), informativ |
| `scripts/check-cbom.sh` | Anti-Staleness: schlägt fehl, wenn ein Krypto-Import nicht im CBOM steht |

- `release.yml` security-gate: CBOM-Konsistenz + conftest-NIST-Check als **harte Gate-Schritte**
- `cbom.yml`: Dependency-SBoM als `sbom.cdx.json`, CBOM validieren + conftest (informativ), beide BoMs hochladen
- TLS war bereits gepinnt (aus den Security-Findings) — CBOM-Aussage belastbar

**Verifikation (lokal, conftest v0.68.2):** echter CBOM 3 pass + 1 Quantum-Warnung; SHA-1/MD5/TLS1.0 → 3 Failures (Gate nicht-vacuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)