### PR TITLE
docs: gesamte Doku auf aktuellen Stand bringen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,20 +23,29 @@ go build -o backup ./cmd/backup
 | Path | Purpose |
 |------|---------|
 | `internal/api/endpoints.go` | All 21 endpoints (edit here to add/remove) |
-| `internal/api/client.go` | HTTP client — GET-only, rate limiter 250/5min, retry 429+5xx |
+| `internal/api/client.go` | HTTP client — GET-only, explicit TLS≥1.2, rate limiter 250/5min, retry 429+5xx |
+| `internal/api/pagination.go` | Page accumulation with url.Values query + per-endpoint item cap |
 | `internal/backup/backup.go` | Worker pool (5), fetches all endpoints |
-| `internal/backup/manifest.go` | SHA256 per file + HMAC-SHA-256 .sig |
-| `internal/storage/writer.go` | Timestamped dirs, 0600 files, path sanitising |
-| `cmd/backup/main.go` | CLI entry point |
+| `internal/backup/manifest.go` | SHA256 per file + HMAC-SHA-256 .sig, error sanitization, hex-decoded verify |
+| `internal/storage/writer.go` | Timestamped dirs, 0600 files, path sanitising + symlink resolution |
 | `docs/api-snapshot.json` | Baseline of Holaspirit API field structure (for drift detection) |
+| `scripts/check-api-schema.sh` | Credential-free API drift check vs published OpenAPI spec |
+| `scripts/check-cbom.sh` | Anti-staleness: every crypto import must be in the CBOM |
+| `docs/cbom.cdx.json` | CycloneDX 1.6 Cryptography BoM (hand-authored) |
+| `policy/nist-crypto.rego` | OPA/conftest NIST crypto policy (gates the release) |
 
 ## Architecture
 
 - **GET-only**: client has only `Get()` — no Post/Patch/Delete possible
 - **No token exposure**: no `Token()` accessor, token never in logs/errors
+- **TLS**: explicit minimum TLS 1.2, `InsecureSkipVerify` hard-false
 - **File perms**: 0600 files, 0750 dirs
 - **HMAC key**: domain-separated (`holaspirit-backup-manifest-v1` prefix)
-- **Worker pool**: 5 bounded goroutines
+- **Log-injection guard**: API/operator values sanitized before logging
+- **Symlink guard**: output dir resolved + containment-checked before writing
+- **Worker pool**: 5 bounded goroutines; per-endpoint item cap bounds memory
+- **CBOM**: real crypto surface in `docs/cbom.cdx.json`, checked against NIST
+  SP 800-131A via OPA/conftest; non-approved algorithm or TLS<1.2 gates the release
 - **vendor/** checked in for supply-chain safety
 
 ## CI/CD Workflows
@@ -46,10 +55,11 @@ go build -o backup ./cmd/backup
 | `security-and-quality.yml` | push + PR | govulncheck, gosec, go test -race |
 | `build.yml` | push main + tags + PR | 3 platform binaries |
 | `release.yml` | `v*` tags | GitHub Release, SLSA provenance, cosign signing |
-| `cbom.yml` | push + PR | CycloneDX SBoM (`--type go`) |
-| `scorecard.yml` | push main + weekly | OpenSSF Scorecard (needs `SCORECARD_ENABLED=true` var + `SCORECARD_TOKEN` secret) |
+| `cbom.yml` | push + PR | Dependency SBoM (`sbom.cdx.json`) + CBOM validation + conftest NIST check (informational) |
+| `scorecard.yml` | push main + weekly | OpenSSF Scorecard (`SCORECARD_ENABLED=true`; `SCORECARD_TOKEN` optional) |
 | `commit-signature.yml` | push + PR | GPG commit check (needs `COMMIT_SIGNING_ENABLED=true` var + `COMMIT_SIGNING_PUBLIC_KEY` secret) |
-| `dependency-review.yml` | PR only | Block high-severity CVEs |
+| `dependency-review.yml` | PR + merge_group | Block high-severity CVEs + license allowlist |
+| `dependabot-auto-merge.yml` | Dependabot PR | Auto-merge non-major bumps once CI is green |
 | `api-update-check.yml` | daily 06:00 UTC | Spec-based drift detection → Claude adapts code → api-drift PR |
 | `auto-release.yml` | api-drift PR merged | Bump 0ver minor, push tag → triggers release |
 
@@ -64,14 +74,15 @@ api-update-check (daily 06:00 UTC — no credentials needed)
   → PR with label api-drift (auto-merge only if snapshot-only;
     Go/script changes always require human review — prompt-injection guard)
   → merge → auto-release bumps 0ver minor + pushes tag
-  → release workflow: security-gate (govulncheck, gosec, race tests,
-    blocks while issues labeled `security` are open) → build → signed release
+  → release workflow: security-gate (govulncheck, gosec, race tests, CBOM NIST
+    policy, blocks while issues labeled `security` are open) → build → signed release
 ```
 
 - Baseline: `docs/api-snapshot.json` (committed); sentinel `__ENDPOINT_MISSING__`
   marks endpoints the tool calls that are no longer documented
-- NOTE: releases are blocked until the open security review findings
-  (issues #9–#33, labels `security`/`severity:*`) are resolved — by design
+- The original security review findings (issues #9–#33) are all resolved; the
+  security-gate now passes (release v0.2.0 shipped). It will block again if any
+  new `security`-labeled issue is opened — by design
 - Exit 2 (spec download failed) fails the job; no snapshot is written
 
 ## Repo
@@ -80,17 +91,23 @@ api-update-check (daily 06:00 UTC — no credentials needed)
 - Versioning: 0ver — major stays 0, e.g. `v0.2.0` (see https://0ver.org/)
 - go.mod: `go 1.25.8`, but CI uses `go-version: '1.26'` — do not change
 
-## Pending Manual Steps
+## Dependency Updates (Dependabot)
 
-- Set `SCORECARD_TOKEN` secret (optional — only improves Branch-Protection check)
-- Set `COMMIT_SIGNING_PUBLIC_KEY` secret (GPG public key)
-- Set `ANTHROPIC_API_KEY` secret **or** `CLAUDE_CODE_OAUTH_TOKEN` secret (Pro/Max
-  subscription via `claude setup-token`) — enables automatic code adaptation on drift
-- Set `REPO_PAT` secret (PAT with repo + workflow scope — lets drift PRs trigger CI
-  and auto-release tags trigger the release workflow)
-- Resolve open security findings #9–#33 (release security-gate blocks until then)
-- HOLASPIRIT_TOKEN / HOLASPIRIT_ORG_ID are **no longer needed** for the drift
-  check (it now reads the public OpenAPI spec)
+- `dependabot.yml`: daily, with a 7-day `cooldown` (supply-chain maturity window
+  — a release is only proposed a week after publication; security advisories bypass it)
+- `dependabot-auto-merge.yml`: auto-merges non-major bumps once required CI is green
+  (build + security-and-quality + dependency-review); major bumps stay open for review
+- Branch ruleset `main-protection` enforces PR + required checks before any merge
+
+## Configured (was "pending")
+
+- ✅ Security findings #9–#33 resolved; release v0.2.0 shipped (gate passes)
+- ✅ Secrets CLAUDE_CODE_OAUTH_TOKEN + REPO_PAT set; SCORECARD_ENABLED=true
+- ✅ "Allow auto-merge" enabled; `main-protection` ruleset active; Actions cannot approve PRs
+- ✅ Secret scanning + push protection + private vulnerability reporting on
+- HOLASPIRIT_TOKEN / HOLASPIRIT_ORG_ID are **no longer needed** (drift check reads the public spec)
+- Optional, still open: SCORECARD_TOKEN (improves Branch-Protection check only),
+  COMMIT_SIGNING_PUBLIC_KEY + COMMIT_SIGNING_ENABLED (to enforce signed commits)
 
 ## Confluence (HB Space, cloudId: 78b5b3f6-a4c9-4f9d-856e-56eca016288c)
 

--- a/README.md
+++ b/README.md
@@ -76,24 +76,38 @@ Optionen:
 
 | Maßnahme | Details |
 |----------|---------|
-| SLSA Level 2 | Provenance-Attestation via `actions/attest-build-provenance`, verifikbar mit `gh attestation verify` |
+| SLSA Level 2 | Provenance-Attestation via `actions/attest-build-provenance`, verifizierbar mit `gh attestation verify` |
 | cosign | Keyless-Signing aller Release-Binaries via Sigstore OIDC |
 | HMAC-SHA-256 | Manifest-Signatur jedes Backups (`backup-manifest.sig`) |
 | GET-only API | HTTP-Client exponiert nur `Get()` — kein Schreibzugriff möglich |
+| TLS ≥ 1.2 | Explizit erzwungen, Zertifikatsprüfung nicht abschaltbar |
+| Release-Security-Gate | Release blockiert bei offenen `security`-Issues, fehlgeschlagenem govulncheck/gosec/Race-Test oder nicht-NIST-konformer Krypto |
+| CBOM + NIST-Policy | `docs/cbom.cdx.json` (CycloneDX 1.6) gegen NIST SP 800-131A via OPA/conftest geprüft |
 | SHA-gepinnte Actions | Alle CI-Actions auf Commit-SHA gepinnt (Supply-Chain-Schutz) |
 | govulncheck + gosec | SAST bei jedem Push (versionsgepinnt) |
 | OpenSSF Scorecard | Wöchentliches Security-Scoring (GitHub Security tab) |
+| Dependabot | 7-Tage-Cooldown + Auto-Merge reifer Minor/Patch-Bumps; Major manuell |
+| Branch-Protection | `main`-Ruleset: PR + Pflicht-Checks erzwungen, kein Force-Push |
 | vendor/ committed | Supply-Chain: alle Abhängigkeiten eingecheckt |
 
 Sicherheitslücken bitte per [GitHub Private Vulnerability Reporting](https://github.com/kAYd9iN/holaspirit-backup/security/advisories/new) melden — siehe [SECURITY.md](SECURITY.md).
+
+## Self-Update-Schlaufe
+
+Ein täglicher Workflow (`api-update-check`) vergleicht Holaspirits publizierte
+OpenAPI-Spec (aus der öffentlichen `/api/doc/`-Seite) gegen die committete
+Baseline (`docs/api-snapshot.json`) — ohne Credentials. Bei Drift passt Claude
+den Code automatisch an und öffnet einen PR; nach dem Merge erzeugt `auto-release`
+einen versionierten, signierten Release (sofern das Security-Gate frei ist).
 
 ## Dokumentation
 
 - [Architektur](docs/architecture.md) — Projektstruktur, Ablauf, Manifest-Format
 - [Sicherheitskonzept](docs/security-concept.md) — Prinzipien, Token-Verwaltung, CI-Security, Pentest-Ergebnisse
+- [Trust-Model](docs/trust-model.md) — Vertrauensgrenzen, was die HMAC-Signatur garantiert (und was nicht)
 - [Betrieb & Installation](docs/operations.md) — Installation, Windows Task Scheduler, Veeam-Integration
-- [Supply Chain & Vertrauenskette](docs/supply-chain.md) — SLSA L2, cosign, Scorecard, Verifikationsanleitung
-- [Security Policy](SECURITY.md) — Sicherheitslücken melden
+- [Supply Chain & Vertrauenskette](docs/supply-chain.md) — SLSA L2, cosign, Scorecard, CBOM, Verifikationsanleitung
+- [Security Policy](SECURITY.md) — Sicherheitslücken melden, Krypto-/Daten-Sicherheit
 
 ## Entwicklung
 
@@ -104,7 +118,10 @@ go test -race -cover ./...
 # Build
 go build -mod=vendor -ldflags="-X main.version=dev" -o backup ./cmd/backup/
 
-# Security-Scan
-go run golang.org/x/vuln/cmd/govulncheck@v1.1.3 ./...
-go run github.com/securego/gosec/v2/cmd/gosec@v2.21.4 ./...
+# Security-Scan (gleiche Versionen wie CI)
+go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+go run github.com/securego/gosec/v2/cmd/gosec@v2.24.7 ./...
+
+# CBOM gegen NIST-Policy prüfen
+go run github.com/open-policy-agent/conftest@v0.68.2 test docs/cbom.cdx.json --policy policy
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,28 +22,40 @@ holaspirit-backup/
 │   │   ├── credentials.go       # Interface + Mock
 │   │   └── wincred.go           # Windows Credential Manager (build tag windows)
 │   └── storage/
-│       └── writer.go            # Dateien schreiben, Pfad-Sanitizing, 0600/0750
+│       └── writer.go            # Dateien schreiben, Pfad-Sanitizing + Symlink-Auflösung, 0600/0750
 ├── scripts/
-│   └── verify_signed_commits.sh # GPG-Commit-Signatur-Prüfung
+│   ├── verify_signed_commits.sh # GPG-Commit-Signatur-Prüfung
+│   ├── check-api-schema.sh      # credential-freier API-Drift-Check (publizierte Spec)
+│   └── check-cbom.sh            # CBOM-Konsistenz (Krypto-Import muss im CBOM stehen)
+├── policy/
+│   └── nist-crypto.rego         # OPA/conftest NIST-Krypto-Policy (gatet Release)
 ├── vendor/                      # eingecheckte Abhängigkeiten
 ├── docs/
 │   ├── architecture.md          # diese Datei
 │   ├── security-concept.md      # Sicherheitskonzept
+│   ├── trust-model.md           # Vertrauensgrenzen
 │   ├── operations.md            # Betrieb & Installation
-│   ├── supply-chain.md          # SLSA, cosign, Scorecard
+│   ├── supply-chain.md          # SLSA, cosign, Scorecard, CBOM
+│   ├── api-snapshot.json        # Drift-Check-Baseline
+│   ├── cbom.cdx.json            # CycloneDX 1.6 Cryptography BoM
 │   └── plans/                   # Implementierungspläne
 ├── go.mod
 ├── go.sum
 ├── SECURITY.md                  # GitHub Security Policy
-└── .github/
-    └── workflows/
-        ├── security.yml         # govulncheck + gosec + Tests
-        ├── build.yml            # Matrix-Build (3 Plattformen)
-        ├── release.yml          # GitHub Release + SLSA L2 + cosign + SHA256
-        ├── cbom.yml             # CycloneDX CBOM
-        ├── commit-signature.yml # GPG-Commit-Prüfung
-        ├── scorecard.yml        # OpenSSF Scorecard (wöchentlich)
-        └── dependency-review.yml # CVE-Prüfung bei PRs
+├── .github/
+│   ├── dependabot.yml           # täglich, 7-Tage-Cooldown
+│   └── workflows/
+│       ├── security.yml         # govulncheck + gosec + Tests
+│       ├── build.yml            # Matrix-Build (3 Plattformen)
+│       ├── release.yml          # Security-Gate → SLSA L2 + cosign + SHA256
+│       ├── cbom.yml             # Dependency-SBoM + CBOM + NIST-conftest
+│       ├── commit-signature.yml # GPG-Commit-Prüfung
+│       ├── scorecard.yml        # OpenSSF Scorecard (wöchentlich)
+│       ├── dependency-review.yml # CVE- + Lizenz-Prüfung bei PRs
+│       ├── dependabot-auto-merge.yml # Auto-Merge reifer Non-Major-Bumps
+│       ├── api-update-check.yml # täglicher Spec-Drift-Check → Claude → PR
+│       └── auto-release.yml     # api-drift-Merge → Tag → Release
+└── (Self-Update-Schlaufe: siehe CLAUDE.md)
 ```
 
 ## Architekturentscheidung: Bounded Worker Pool mit Rate-Limiter

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -93,7 +93,7 @@ C:\Tools\holaspirit-backup\backup.exe --dry-run
 Erwartete Ausgabe:
 
 ```
-time=2026-03-06T02:00:00Z level=INFO msg="organization discovered" id=org_xxx
+time=2026-03-06T02:00:00Z level=INFO msg="organization confirmed" id=org_xxx
 time=2026-03-06T02:00:00Z level=INFO msg="dry run successful — connection OK"
 ```
 
@@ -106,7 +106,7 @@ C:\Tools\holaspirit-backup\backup.exe --output C:\Backups\holaspirit
 Erwartete Ausgabe:
 
 ```
-time=2026-03-06T02:00:00Z level=INFO msg="organization discovered" id=org_xxx
+time=2026-03-06T02:00:00Z level=INFO msg="organization confirmed" id=org_xxx
 time=2026-03-06T02:00:00Z level=INFO msg="backup directory created" path=C:\Backups\holaspirit\2026-03-06T02-00-00
 time=2026-03-06T02:00:00Z level=INFO msg="fetching endpoints" count=21
 time=2026-03-06T02:00:45Z level=INFO msg="endpoint ok" name=circles records=42
@@ -177,6 +177,7 @@ Hauptbefehl:
   --org-id ID       Organisations-ID (optional, wird automatisch ermittelt)
   --dry-run         Verbindung testen ohne Daten zu schreiben
   --timeout MIN     Gesamt-Timeout in Minuten (Standard: 120, 0 = kein Timeout)
+  --audit           Hostname + Benutzer im Manifest erfassen (Audit-Trail)
   --version         Version anzeigen
   --help            Hilfe anzeigen
 

--- a/docs/security-concept.md
+++ b/docs/security-concept.md
@@ -9,14 +9,20 @@
 - **Supply Chain Security:** Alle Go-Abhängigkeiten via `go mod vendor` eingecheckt; alle CI-Actions auf Commit-SHA gepinnt
 - **SAST im CI:** `gosec` und `govulncheck` bei jedem Push (pinned versions)
 - **Path Traversal Prevention:** Dateinamen werden vor dem Schreiben sanitiert (`[^a-zA-Z0-9_-]` → `_`) und per `filepath.Rel` gegen das Zielverzeichnis geprüft (beide Methoden: WriteJSON + WriteFile)
+- **Symlink-Schutz:** Das `--output`-Verzeichnis wird via `EvalSymlinks` aufgelöst und nach dem Anlegen erneut auf Containment geprüft (kein Schreiben durch einen Symlink hindurch)
 - **Input Validation:** OrgID wird per Regexp validiert bevor sie in URLs injiziert wird
+- **Log-Injection-Schutz:** API-/Operator-Werte werden vor dem Logging von Steuerzeichen/ANSI-Sequenzen bereinigt
+- **Fehler-Sanitisierung:** Im Manifest gespeicherte Fehlerstrings werden bereinigt und gekürzt (kein Roh-API-Fehler auf Disk)
+- **TLS-Policy:** Mindestens TLS 1.2 explizit erzwungen, `InsecureSkipVerify` hart auf `false`
 - **Dateiberechtigungen:** Backup-Dateien `0600`, Verzeichnisse `0750`
 - **Response-Limit:** HTTP-Responses auf 100 MiB begrenzt (Schutz vor Memory-Exhaustion)
-- **Pagination-Guard:** Max. 500 Seiten pro Endpunkt (Schutz vor endlosen Loops)
+- **Pagination-Guard:** Max. 500 Seiten **und** max. 1 Mio. Items pro Endpunkt (Schutz vor endlosen Loops und Memory-Exhaustion)
 - **SLSA Level 2:** Jedes Release-Binary erhält eine signierte Provenance-Attestation
 - **cosign Keyless Signing:** Release-Binaries werden via Sigstore OIDC signiert
 - **OpenSSF Scorecard:** Wöchentliches automatisches Security-Scoring des Repos
-- **Dependency Review:** PRs werden auf neue hochschwere CVEs geprüft (CVSS ≥ 7.0)
+- **Dependency Review:** PRs werden auf neue hochschwere CVEs **und** auf nicht-permissive Lizenzen geprüft (Allowlist: MIT/Apache-2.0/BSD/ISC)
+- **Release-Security-Gate:** Ein Release wird blockiert, solange `security`-Issues offen sind, govulncheck/gosec/Race-Tests fehlschlagen oder der CBOM nicht NIST-konform ist
+- **CBOM + NIST-Policy:** Krypto-Oberfläche als CycloneDX-1.6-CBOM, gegen NIST SP 800-131A via OPA/conftest geprüft (siehe unten)
 
 ## Secrets Management: Windows Credential Manager
 
@@ -76,11 +82,14 @@ dass ein Bug oder eine fehlerhafte Erweiterung Holaspirit-Daten verändert.
 |----------|---------|-------|
 | `security.yml` | Push, PR | govulncheck + gosec + Tests (race detector) |
 | `build.yml` | Push main, Tags, PR | Matrix-Build (linux/amd64, linux/arm64, windows/amd64) |
-| `release.yml` | `v*` Tags | GitHub Release + SLSA L2 Attestation + cosign Signing + SHA256 |
-| `cbom.yml` | Push, PR | CycloneDX CBOM generieren + optional signieren |
+| `release.yml` | `v*` Tags | Security-Gate → SLSA L2 Attestation + cosign Signing + SHA256 |
+| `cbom.yml` | Push, PR | Dependency-SBoM + CBOM-Validierung + conftest-NIST-Check (informativ) |
 | `commit-signature.yml` | Push main, PR | GPG-Signatur aller Commits prüfen |
 | `scorecard.yml` | Push main, wöchentlich | OpenSSF Scorecard Security-Scoring |
-| `dependency-review.yml` | PRs auf main | Neue Abhängigkeiten auf CVEs prüfen |
+| `dependency-review.yml` | PRs, merge_group | Neue Abhängigkeiten auf CVEs + Lizenz-Allowlist prüfen |
+| `dependabot-auto-merge.yml` | Dependabot-PR | Auto-Merge reifer Minor/Patch-Bumps nach grüner CI |
+| `api-update-check.yml` | täglich 06:00 UTC | Spec-basierte Drift-Erkennung → Claude-Anpassung → api-drift-PR |
+| `auto-release.yml` | api-drift-PR gemerged | 0ver-Minor-Bump + Tag → triggert Release |
 
 Alle `actions/*`-Referenzen sind auf Commit-SHA gepinnt (Schutz gegen Tag-Manipulation und Typosquatting).
 
@@ -116,15 +125,32 @@ holaspirit-backup verify --dir /mnt/backups/holaspirit/2026-03-06T02-00-00
 # Exit 1 = Manipulation oder falscher Token erkannt
 ```
 
-## CBOM (Cryptography Bill of Materials)
+## SBoM und CBOM
 
-Bei jedem CI-Lauf wird via [CycloneDX cdxgen](https://github.com/CycloneDX/cdxgen) ein  
-Cryptography Bill of Materials generiert. Es dokumentiert alle kryptografischen Primitive  
-und Bibliotheken im Projekt.
+Zwei getrennte Stücklisten:
 
-- **Format:** CycloneDX JSON (`cbom.cdx.json`)
-- **Speicherung:** GitHub Actions Artifact `cbom-cyclonedx` (365 Tage Aufbewahrung)
-- **Optionale Signierung:** Wenn Secret `CBOM_SIGNING_KEY_PEM` konfiguriert ist, wird das CBOM mit OpenSSL SHA256 signiert (`cbom.cdx.json.sig`)
+**Dependency-SBoM** (`sbom.cdx.json`) — via [CycloneDX cdxgen](https://github.com/CycloneDX/cdxgen)
+`--type go`: alle Go-Modul-Abhängigkeiten mit PURLs, Hashes und Lizenzen. Das ist
+**kein** CBOM — Go-Stdlib-Krypto ist keine go.mod-Abhängigkeit und taucht hier nicht auf.
+
+**CBOM** (`docs/cbom.cdx.json`) — die tatsächliche Krypto-Oberfläche als CycloneDX-1.6
+mit `cryptographic-asset`-Komponenten. Da automatisierte Scanner (cdxgen, cbomkit-theia)
+Go-Stdlib-Krypto nicht erkennen, wird der CBOM **hand-gepflegt** und durch
+`scripts/check-cbom.sh` ehrlich gehalten (CI schlägt fehl, wenn ein Krypto-Import in
+`internal/`/`cmd/` nicht im CBOM deklariert ist).
+
+Erfasste Assets: **SHA-256** (Hashing), **HMAC-SHA-256** (Manifest-Signatur),
+**TLS ≥ 1.2** (Transport), **ECDSA P-256** (cosign Release-Signing).
+
+**NIST-Compliance-Gate:** Der CBOM wird gegen eine NIST-SP-800-131A-Policy
+([`policy/nist-crypto.rego`](../policy/nist-crypto.rego), OPA/conftest) geprüft. Ein
+nicht-zugelassener Algorithmus (z.B. MD5, SHA-1, RC4 oder TLS < 1.2) lässt das
+**Release-Security-Gate fehlschlagen**. Quantensicherheit wird als nicht-blockierende
+Warnung ausgewiesen: ECDSA P-256 ist NIST-konform, aber nicht quantensicher
+(für spätere PQC-Migration vermerkt).
+
+- **Aufbewahrung:** GitHub Actions Artifact `bom-cyclonedx` (SBoM + CBOM, 365 Tage)
+- **Optionale Signierung:** mit Secret `CBOM_SIGNING_KEY_PEM` werden beide BoMs via OpenSSL SHA256 signiert
 
 ## Netzwerk
 
@@ -132,9 +158,11 @@ und Bibliotheken im Projekt.
 - Keine eingehenden Verbindungen nötig
 - HTTP-Timeouts: 30s pro API-Request, 2h gesamt (konfigurierbar via `--timeout`)
 
-## Pentest-Ergebnisse
+## Security-Reviews
 
-Eine vollständige interne Sicherheitsprüfung (OWASP Top 10 + toolspezifische Analyse) wurde durchgeführt.  
+### Erster Pentest (#1–#8)
+
+Eine erste interne Sicherheitsprüfung (OWASP Top 10 + toolspezifische Analyse) wurde durchgeführt.  
 Alle Findings sind als GitHub Issues erfasst (#1–#8) und behoben:
 
 | ID | Schwere | Finding | Status |
@@ -147,3 +175,19 @@ Alle Findings sind als GitHub Issues erfasst (#1–#8) und behoben:
 | SEC-06 | Low | `orgID` ohne Validierung in URL | Behoben: `ValidateOrgID()` |
 | SEC-07 | Low | Token ohne `TrimSpace` | Behoben |
 | SEC-08 | Low | `codeql-action` nicht SHA-gepinnt | Behoben |
+
+### Umfassendes Security-Review (#9–#33)
+
+Ein zweites, umfassenderes Review (Personas: Security Architect/Engineer, Pentester, SSDM)
+brachte 25 weitere Findings (#9–#33, davon 5× `severity:high`). **Alle behoben** (PR #42);
+das Release-Security-Gate gibt seither frei (Release v0.2.0 erstellt). Auflösungen:
+
+- **Code-Fixes:** TLS-Policy (#12/#29), Hex-decodierter HMAC-Vergleich (#13),
+  `LimitReader` beim Manifest-Hashing (#14), Fehler-Sanitisierung (#15),
+  Symlink-Auflösung (#17), Log-Injection-Schutz (#18), Item-Cap (#19),
+  `verify`-Pfad-Auflösung (#21), URL-Encoding (#30), Opt-in-Audit-Trail (#33)
+- **Workflow:** Least-Privilege-Permissions (#25), Lizenz-Allowlist (#24), Branch-Ruleset (#26)
+- **Dokumentierte Design-Entscheidungen** (SECURITY.md, [trust-model.md](trust-model.md)):
+  Verschlüsselung-at-Rest (#9), Token-Rotation/HMAC (#10), Retention (#11),
+  Incident-Response (#23), Trust-Model (#27), OrgID-Disclosure (#28)
+- **Durch credential-freien Drift-Check obsolet:** Token im Workflow (#22), Shell-Injection (#20)

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -13,22 +13,30 @@ Source Code (GitHub)
     ▼
 CI-Build (GitHub Actions — gehosteter Runner)
     │
-    ├─ govulncheck (CVE-Scan, @v1.1.3)
-    ├─ gosec (SAST, @v2.21.4)
+    ├─ govulncheck (CVE-Scan, @v1.1.4)
+    ├─ gosec (SAST, @v2.24.7)
     ├─ go mod verify (vendor-Integrität)
     ├─ go test -race (Tests)
     └─ Alle Actions auf Commit-SHA gepinnt
     │
+    ▼
+Release-Security-Gate (release.yml)
+    │
+    ├─ govulncheck + gosec + Race-Tests
+    ├─ CBOM-Konsistenz (check-cbom.sh) + NIST-Policy (conftest)
+    └─ Block bei offenen `security`-Issues
+    │  (alle Build-Jobs starten erst nach grünem Gate)
     ▼
 Release-Artefakte
     │
     ├─ SLSA L2 Provenance-Attestation (GitHub Attestation Registry)
     ├─ cosign Bundle (Keyless-Signatur via Sigstore/OIDC)
     ├─ SHA256SUMS (Checksummen)
-    └─ CycloneDX CBOM (Cryptography Bill of Materials)
+    └─ SBoM + CBOM (CycloneDX, als Artifact)
     │
     ▼
 OpenSSF Scorecard (wöchentlich) + Dependency Review (PRs)
+    + Dependabot (täglich, 7-Tage-Cooldown, Auto-Merge reifer Bumps)
 ```
 
 ## SLSA Level 2
@@ -137,9 +145,18 @@ Details: [https://securityscorecards.dev](https://securityscorecards.dev)
 
 ## Dependency Review
 
-Bei jedem Pull Request auf `main` wird automatisch geprüft, ob neue oder geänderte  
-Abhängigkeiten bekannte Schwachstellen (CVSS ≥ 7.0) enthalten.  
-Der PR wird blockiert und ein Kommentar mit den Details gepostet.
+Bei jedem Pull Request auf `main` (und in der Merge-Queue) wird automatisch geprüft, ob neue oder geänderte  
+Abhängigkeiten bekannte Schwachstellen (CVSS ≥ 7.0) enthalten **oder** eine nicht-permissive Lizenz tragen  
+(Allowlist: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC). Der PR wird blockiert und ein Kommentar mit den Details gepostet.  
+Direkte Pushes auf `main` sind durch das `main-protection`-Ruleset ausgeschlossen, sodass diese Prüfung nicht umgangen werden kann.
+
+## Dependabot — Reifezeit & Auto-Merge
+
+Abhängigkeits-Updates durchlaufen eine **Supply-Chain-Reifezeit**, bevor sie übernommen werden:
+
+- **Cooldown:** Ein Release wird erst **7 Tage nach Veröffentlichung** als PR vorgeschlagen (`cooldown: default-days: 7` in `dependabot.yml`). So werden kompromittierte oder zurückgezogene Versionen meist erkannt, bevor sie gemerged werden. **Security-Advisories umgehen den Cooldown** (sofort).
+- **Täglich:** Nach Ablauf der Reifezeit wird der PR beim nächsten täglichen Check geöffnet.
+- **Auto-Merge:** `dependabot-auto-merge.yml` merged **Minor/Patch automatisch**, sobald die Pflicht-CI (Build + security-and-quality + dependency-review) grün ist. **Major-Bumps bleiben für manuelle Review offen.**
 
 ## vendor/ — eingecheckte Abhängigkeiten
 
@@ -156,11 +173,13 @@ Integrität prüfen:
 go mod verify
 ```
 
-## CycloneDX CBOM
+## SBoM und CBOM
 
-Bei jedem CI-Lauf wird ein Cryptography Bill of Materials (CBOM) generiert:
+Bei jedem CI-Lauf werden zwei getrennte Stücklisten erzeugt (Artefakt `bom-cyclonedx`, 365 Tage):
 
-- Dokumentiert alle kryptografischen Primitive und Bibliotheken
-- Format: CycloneDX JSON
-- Artefakt: `cbom-cyclonedx` (365 Tage in GitHub Actions)
-- Optionale Signierung via `CBOM_SIGNING_KEY_PEM` Secret
+- **Dependency-SBoM** (`sbom.cdx.json`) — via cdxgen `--type go`: alle Modul-Abhängigkeiten mit PURLs, Hashes, Lizenzen. **Kein** CBOM (Go-Stdlib-Krypto erscheint hier nicht).
+- **CBOM** (`docs/cbom.cdx.json`) — die tatsächliche Krypto-Oberfläche als CycloneDX 1.6 mit `cryptographic-asset`-Komponenten (SHA-256, HMAC-SHA-256, TLS ≥ 1.2, ECDSA P-256). Hand-gepflegt, da automatisierte Scanner Go-Stdlib-Krypto nicht erkennen; `scripts/check-cbom.sh` hält ihn ehrlich.
+
+**NIST-Compliance-Gate:** Der CBOM wird via OPA/conftest gegen `policy/nist-crypto.rego` (NIST SP 800-131A) geprüft. Ein nicht-zugelassener Algorithmus oder TLS < 1.2 lässt das Release-Security-Gate fehlschlagen. Quantensicherheit ist eine nicht-blockierende Warnung (ECDSA P-256). Lokal: `go run github.com/open-policy-agent/conftest@v0.68.2 test docs/cbom.cdx.json --policy policy`.
+
+- Optionale Signierung beider BoMs via `CBOM_SIGNING_KEY_PEM` Secret


### PR DESCRIPTION
Vollständiger Doku-Konsistenz-Durchgang über alle lebenden Dokumente.

**Wichtigste Korrekturen:**
- security-concept.md + supply-chain.md behaupteten, cdxgen generiere einen CBOM, der "alle kryptografischen Primitive dokumentiert" — faktisch falsch (cdxgen erfasst Go-Stdlib-Krypto nicht). Korrigiert: SBoM vs. echter hand-gepflegter CBOM + NIST-conftest-Gate.
- Veraltete Tool-Versionen (govulncheck v1.1.3 -> v1.1.4, gosec v2.21.4 -> v2.24.7) an die CI angeglichen.
- Findings #9-#33 waren als offen/blockierend dokumentiert — jetzt als gelöst markiert (Release v0.2.0).
- README/CLAUDE/architecture: TLS-Pin, CBOM/NIST-Gate, Dependabot-Cooldown/Auto-Merge, Branch-Protection, neue Workflows/Skripte/policy, --audit-Flag ergänzt.

Dated Plans und der CI-Audit vom 2026-03-07 bleiben als Zeitdokumente unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
