### PR TITLE
fix: UTF-16LE Windows-Credential dekodieren (ungültiger Authorization-Header)

### DIFF
--- a/internal/credentials/credblob.go
+++ b/internal/credentials/credblob.go
@@ -1,0 +1,33 @@
+package credentials
+
+import (
+	"strings"
+	"unicode/utf16"
+)
+
+// decodeCredentialBlob converts a Windows Credential Manager blob to a string.
+// `cmdkey` stores passwords as UTF-16LE, so reading the raw blob as a Go string
+// leaves a NUL byte after every ASCII character — which makes an invalid HTTP
+// Authorization header. Decode UTF-16LE when the blob looks like it (even
+// length with embedded NULs); otherwise treat it as a plain UTF-8 string.
+// Surrounding whitespace/newlines are trimmed either way.
+//
+// This lives in a platform-neutral file (no build tag) so it is compiled and
+// unit-tested on the Linux CI, even though its only caller is Windows-only.
+func decodeCredentialBlob(b []byte) string {
+	hasNUL := false
+	for _, c := range b {
+		if c == 0 {
+			hasNUL = true
+			break
+		}
+	}
+	if len(b)%2 == 0 && hasNUL {
+		u16 := make([]uint16, len(b)/2)
+		for i := range u16 {
+			u16[i] = uint16(b[2*i]) | uint16(b[2*i+1])<<8 // little-endian
+		}
+		return strings.TrimSpace(string(utf16.Decode(u16)))
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/credentials/credblob_test.go
+++ b/internal/credentials/credblob_test.go
@@ -1,0 +1,46 @@
+package credentials
+
+import (
+	"testing"
+	"unicode/utf16"
+)
+
+func utf16le(s string) []byte {
+	u := utf16.Encode([]rune(s))
+	b := make([]byte, len(u)*2)
+	for i, v := range u {
+		b[2*i] = byte(v)
+		b[2*i+1] = byte(v >> 8)
+	}
+	return b
+}
+
+func TestDecodeCredentialBlob(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"utf16le token (cmdkey)", utf16le("api:abc123"), "api:abc123"},
+		{"utf16le with trailing newline", utf16le("api:abc123\n"), "api:abc123"},
+		{"plain utf8", []byte("api:xyz789"), "api:xyz789"},
+		{"plain utf8 with whitespace", []byte("  api:xyz789\r\n"), "api:xyz789"},
+		{"empty", []byte{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := decodeCredentialBlob(tt.in); got != tt.want {
+				t.Errorf("decodeCredentialBlob(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeCredentialBlob_NoNULsLeftForHeader(t *testing.T) {
+	got := decodeCredentialBlob(utf16le("api:token"))
+	for i := 0; i < len(got); i++ {
+		if got[i] == 0 {
+			t.Fatalf("decoded token still contains a NUL byte at %d", i)
+		}
+	}
+}

--- a/internal/credentials/wincred.go
+++ b/internal/credentials/wincred.go
@@ -24,5 +24,5 @@ func (w *WinCredManager) GetToken() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("credential %q not found in Windows Credential Manager: %w", w.name, err)
 	}
-	return string(cred.CredentialBlob), nil
+	return decodeCredentialBlob(cred.CredentialBlob), nil
 }


### PR DESCRIPTION
Spiegelt confluence-backup PR #53. `cmdkey` speichert Credentials als UTF-16LE; `wincred.go` las den rohen Blob mit `string(cred.CredentialBlob)` → NUL nach jedem ASCII-Zeichen → ungültiger `Authorization`-Header. Backup über den Windows Credential Manager war damit kaputt.

- `credblob.go`: plattformneutrale `decodeCredentialBlob()` (ohne Build-Tag → in der Linux-CI getestet); UTF-16LE-Dekodierung mit NULs, sonst Plain-UTF-8, trimmt Whitespace
- `credblob_test.go`: UTF-16LE, trailing Newline, Plain-UTF-8, NUL-frei-Regression
- `wincred.go`: ruft `decodeCredentialBlob()` statt `string()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)