### PR TITLE
fix: scorecard Job-Level-Permissions wiederherstellen (SARIF-Upload)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,6 +20,10 @@ jobs:
     # This job is skipped (not silently green) when the secret is absent.
     runs-on: ubuntu-latest
     if: ${{ vars.SCORECARD_ENABLED == 'true' }}
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10


### PR DESCRIPTION
Der Scorecard-Findings-PR reduzierte scorecard.yml auf top-level `contents: read`, vergass aber den Job-Level-Permissions-Block — dadurch verlor der Job `security-events: write`/`id-token: write` und der SARIF-Upload schlug fehl ('All jobs have failed'). Block wiederhergestellt (confluence hatte ihn korrekt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)