### PR TITLE
Reference slsa-github-generator by tag, not SHA

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -13,7 +13,10 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0
+    # NOTE: slsa-github-generator MUST be referenced by a semantic version tag,
+    # not a commit SHA — the SLSA verifier needs the version to verify the
+    # builder's own provenance. SHA-pinning causes a startup failure.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
       go-version-file: go.mod
       upload-assets: false


### PR DESCRIPTION
## Summary
The SLSA Go releaser failed with `startup_failure` after the previous PR pinned the builder to a commit SHA.

`slsa-github-generator` **must** be referenced by a semantic version tag (`@v2.1.0`), not a SHA — the SLSA verifier needs the version to verify the builder's own provenance. This is the documented exception to SHA-pinning, and it is safe because the verifier cryptographically validates the tag.

## Test plan
- [ ] CI passes
- [ ] Trigger SLSA Go releaser via `workflow_dispatch` after merge — should now build + generate provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)