### PR TITLE
Grant contents:write to SLSA builder caller job

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -10,9 +10,10 @@ permissions: read-all
 jobs:
   build:
     permissions:
-      id-token: write
-      contents: read
-      actions: read
+      id-token: write   # to sign provenance
+      contents: write   # required: the builder's upload-assets job declares it,
+                        # so the caller must grant it even with upload-assets:false
+      actions: read     # to read the workflow path for provenance
     # NOTE: slsa-github-generator MUST be referenced by a semantic version tag,
     # not a commit SHA — the SLSA verifier needs the version to verify the
     # builder's own provenance. SHA-pinning causes a startup failure.


### PR DESCRIPTION
## Summary
Third and final fix for the SLSA Go releaser `startup_failure`.

The builder's `upload-assets` job declares `permissions: contents: write`. For reusable workflows, GitHub validates at **startup** that the caller grants every permission the called jobs declare. Granting only `contents: read` (even with `upload-assets: false`, which merely skips the job at runtime) caused the startup failure.

Restored `contents: write` at the caller's job level — matching GitHub's own SLSA starter workflow.

## Test plan
- [ ] CI passes
- [ ] `workflow_dispatch` run reaches build/provenance jobs (no startup_failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)