### PR TITLE
Fix .slsa-goreleaser.yml schema (GOOS/GOARCH top-level)

### DIFF
--- a/.slsa-goreleaser.yml
+++ b/.slsa-goreleaser.yml
@@ -1,15 +1,15 @@
 version: 1
 
-env:
-  - GOOS=linux
-  - GOARCH=amd64
+# SLSA Level 3 build configuration for the slsa-github-generator Go builder.
+# Produces a hermetically built linux/amd64 binary with signed provenance.
+goos: linux
+goarch: amd64
 
 main: ./cmd/backup/
-
 binary: backup-linux-amd64
+
+flags:
+  - -mod=vendor
 
 ldflags:
   - "-s -w -X main.version={{ .Tag }}"
-
-goflags:
-  - "-mod=vendor"


### PR DESCRIPTION
## Summary
Fourth fix — the SLSA builder reached the dry-build step and rejected the config with `variable name empty: GOOS`.

- `GOOS`/`GOARCH` must be top-level `goos:`/`goarch:` fields, not `env:` entries
- the build-flags field is `flags:`, not `goflags:`

Rewrote to the correct slsa-goreleaser schema (linux/amd64, `-mod=vendor`, version ldflags).

## Test plan
- [ ] CI passes
- [ ] `workflow_dispatch` run completes the build + provenance jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)