### PR TITLE
Drop -mod=vendor from SLSA config

### DIFF
--- a/.slsa-goreleaser.yml
+++ b/.slsa-goreleaser.yml
@@ -8,8 +8,7 @@ goarch: amd64
 main: ./cmd/backup/
 binary: backup-linux-amd64
 
-flags:
-  - -mod=vendor
-
+# No -mod=vendor flag: the builder's flag allowlist rejects it, and Go uses the
+# checked-in vendor/ directory automatically (go.mod declares go >= 1.14).
 ldflags:
   - "-s -w -X main.version={{ .Tag }}"


### PR DESCRIPTION
## Summary
Fifth fix — the dry build rejected `-mod=vendor` with "unsupported arguments" (the builder's flag allowlist excludes it for reproducibility).

Not needed: Go uses the checked-in `vendor/` directory automatically since `go.mod` declares `go >= 1.14`.

## Test plan
- [ ] CI passes
- [ ] `workflow_dispatch` run completes build + provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)