### PR TITLE
Add id-token: write to api-update-check (OIDC)

### DIFF
--- a/.github/workflows/api-update-check.yml
+++ b/.github/workflows/api-update-check.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write  # claude-code-action authenticates via OIDC
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0


### PR DESCRIPTION
## Summary
Proactive fix mirroring confluence-backup. The Claude adaptation step in `api-update-check` (runs only on drift) needs `id-token: write` for the action's OIDC authentication.

This gap is latent here (Holaspirit hasn't drifted yet) but broke confluence-backup the moment Atlassian changed its API. Fixing now so the self-update loop works the first time Holaspirit's spec drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)