### PR TITLE
fix: adapt to Holaspirit API drift (2026-07-16)

### DIFF
--- a/docs/api-snapshot.json
+++ b/docs/api-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-12T22:10:24Z",
+  "generated": "2026-07-16T07:50:39Z",
   "sources": {
     "doc": {
       "url": "app.holaspirit.com/api/doc/",
@@ -337,6 +337,7 @@
       "logoUrl",
       "meetingConfiguration",
       "memberHierarchyConfiguration",
+      "migration",
       "name",
       "objectiveConfiguration",
       "onboarding",


### PR DESCRIPTION
## Holaspirit API schema update

The daily API schema check found drift against the stored baseline.
Claude adapted the tool to the changes; build and race tests passed.

### Drift
```diff
331a332
>     "migration",
```

Merging this PR triggers the auto-release workflow (api-drift label).
